### PR TITLE
security: fix path traversal vulnerability in candid_integration_tests.py

### DIFF
--- a/bazel/candid_integration_tests/candid_integration_tests.py
+++ b/bazel/candid_integration_tests/candid_integration_tests.py
@@ -14,8 +14,22 @@ if not os.path.isdir(workspace_dir):
 did_file_path = os.path.realpath(os.environ["DID_FILE_PATH"])
 backup_did_file_path = os.path.realpath(os.environ["BACKUP_DID_FILE_PATH"])
 
+# Validate that file paths are within workspace directory
+expected_base_dir = workspace_dir
+try:
+    assert os.path.commonpath([did_file_path, expected_base_dir]) == expected_base_dir
+    assert os.path.commonpath([backup_did_file_path, expected_base_dir]) == expected_base_dir
+except (ValueError, AssertionError):
+    sys.exit("File paths must be within WORKSPACE directory")
+
 
 def modify_file_contents(path, find, replacement):
+    # Validate that path is within workspace directory
+    try:
+        assert os.path.commonpath([path, expected_base_dir]) == expected_base_dir
+    except (ValueError, AssertionError):
+        raise ValueError(f"Path must be within WORKSPACE directory: {path}")
+    
     with open(path) as f:
         contents = f.read()
 


### PR DESCRIPTION
## Security Fix

This PR fixes a **missing input validation** vulnerability in `bazel/candid_integration_tests/candid_integration_tests.py`.

### Vulnerability Details

The `modify_file_contents()` function opens and modifies files based on path arguments without validating that the paths are within an expected directory. Since `did_file_path` and `backup_did_file_path` come from environment variables (`DID_FILE_PATH` and `BACKUP_DID_FILE_PATH`), an attacker who can control these environment variables could modify arbitrary files on the system.

### Fix Applied

1. Added path validation at module initialization (lines 14-19) to verify that both `did_file_path` and `backup_did_file_path` are within the `workspace_dir`.
2. Added path validation in the `modify_file_contents()` function (lines 23-26) to ensure the path argument is within the workspace directory before performing file operations.
3. Uses `os.path.commonpath()` to securely validate that paths are within the expected base directory.

### Security Impact

- Prevents arbitrary file modification through environment variable injection
- Maintains existing functionality while enforcing boundary checks
- Fails safely with clear error messages when paths are outside the workspace

---
**Payout info** (if bounty applies):
- ETH/USDC (Ethereum/Base): `0x46b237D2561a520A5Ef3795911814fd5045Fe01e`
- SOL/USDC (Solana): `A9REHRDTD8DAqbiSxdiTeTA41CqdoJ4QFPzo4FCpQrtL`